### PR TITLE
use fractions in interval! macro

### DIFF
--- a/src/intervals.rs
+++ b/src/intervals.rs
@@ -1,6 +1,6 @@
 #[macro_export]
 macro_rules! interval {
-    ($name:ident, $num:tt, $den:tt) => {
+    ($name:ident, $num:tt / $den:tt) => {
         interval!($name, $num, $den, stringify!($num), stringify!($den));
     };
 
@@ -14,20 +14,20 @@ macro_rules! interval {
     }
 }
 
-interval!(TONIC, 1, 1);
-interval!(SYNTONIC_COMMA, 81, 80);
-interval!(PTOLEMYS_ENHARMONIC, 56, 55);
+interval! { TONIC, 1/1 }
+interval! { SYNTONIC_COMMA, 81/80 }
+interval! { PTOLEMYS_ENHARMONIC, 56/55 }
 
-interval!(SEPTIMAL_COMMA, 36, 35);
-interval!(UNDECIMAL_COMMA, 33, 32);
-interval!(SIXTY_FIFTH_HARMONIC, 65, 64);
+interval! { SEPTIMAL_COMMA, 36/35 }
+interval! { UNDECIMAL_COMMA, 33/32 }
+interval! { SIXTY_FIFTH_HARMONIC, 65/64 }
 
-interval!(OCTAVE, 2, 1);
+interval! { OCTAVE, 2/1 }
 
-interval!(C, 1, 1);
-interval!(D, 9, 8);
-interval!(E, 5, 4);
-interval!(F, 4, 3);
-interval!(G, 3, 2);
-interval!(A, 5, 3);
-interval!(B, 15, 8);
+interval! { C, 1/1 }
+interval! { D, 9/8 }
+interval! { E, 5/4 }
+interval! { F, 4/3 }
+interval! { G, 3/2 }
+interval! { A, 5/3 }
+interval! { B, 15/8 }


### PR DESCRIPTION
previously interval constants were generated like so:

```rust
interval!(TONIC, 1, 1);
```
Now they represented with fractions:

```rust
interval! { TONIC, 1/1 }
```