### PR TITLE
update generated docs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/src/intervals.rs
+++ b/src/intervals.rs
@@ -2,7 +2,7 @@
 macro_rules! interval {
     ($name:ident $num:tt/$den:tt) => {
         #[allow(dead_code)]
-        #[doc = concat!(stringify!($num), "/",stringify!($den))]
+        #[doc = concat!(stringify!($num), "/", stringify!($den))]
         pub const $name: (i32, i32) = ($num, $den);
     };
 

--- a/src/intervals.rs
+++ b/src/intervals.rs
@@ -1,31 +1,16 @@
 #[macro_export]
 macro_rules! interval {
     ($name:ident $num:tt/$den:tt) => {
-        interval!($name, $num, $den, stringify!($num), stringify!($den));
-    };
-
-    ($name:ident, $num:tt, $den:tt, $snum:expr, $sden:expr) => {
         #[allow(dead_code)]
-        #[doc = $snum]
-        #[doc = "/"]
-        #[doc = $sden]
+        #[doc = concat!(stringify!($num), "/",stringify!($den))]
         pub const $name: (i32, i32) = ($num, $den);
     };
 
     ($name:ident $num:tt/$den:tt $notes:tt) => {
-        interval!($name, $num, $den, stringify!($num), stringify!($den), $notes);
-    };
-
-    ($name:ident, $num:tt, $den:tt, $snum:expr, $sden:expr, $notes:expr) => {
         #[allow(dead_code)]
-        #[doc = $snum]
-        #[doc = "/"]
-        #[doc = $sden]
-        #[doc = " ("]
-        #[doc = $notes]
-        #[doc = ")"]
+        #[doc = concat!(stringify!($num), "/", stringify!($den), " - _", $notes, "_")]
         pub const $name: (i32, i32) = ($num, $den);
-    }
+    };
 }
 
 interval! { TONIC  1/1 }


### PR DESCRIPTION
With the release of rust [1.54](https://blog.rust-lang.org/2021/07/29/Rust-1.54.0.html#attributes-can-invoke-function-like-macros), this code can be simplified. 

It also fixes formatting issues in the docs.

Before

![Screen Shot 2021-08-03 at 15 40 42](https://user-images.githubusercontent.com/4027669/128083381-98e3cb2c-580e-470d-a719-2ada06398f31.png)

After

![Screen Shot 2021-08-03 at 15 40 16](https://user-images.githubusercontent.com/4027669/128083348-a2fc6a09-0259-43e2-b476-6515366186bd.png)


